### PR TITLE
Fix stack buffer overwrite caused by missing space for the NULL termi…

### DIFF
--- a/cipher.c
+++ b/cipher.c
@@ -25,7 +25,7 @@ void processInput(FILE *inf, FILE *outf, char substitute[]);
 
 int main(int argc, char *argv[])
 {
-  char encrypt[26], decrypt[26];
+  char encrypt[27], decrypt[27];
   int option;
   char *key;
   FILE *inFile, *outFile;


### PR DESCRIPTION
.…nator This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md)